### PR TITLE
update msgs off and ops can access secure stuff

### DIFF
--- a/src/config/cofh/core/common.cfg
+++ b/src/config/cofh/core/common.cfg
@@ -17,13 +17,13 @@ General {
     B:EnableItemStacking=true
 
     # Set to TRUE to be informed of non-critical updates. You will still receive critical update notifications.
-    B:EnableUpdateNotifications=true
+    B:EnableUpdateNotifications=false
 }
 
 
 Security {
     # Set to TRUE to allow for Server Ops to access 'secure' blocks. Your players will be warned upon server connection.
-    B:OpsCanAccessSecureBlocks=false
+    B:OpsCanAccessSecureBlocks=true
 }
 
 


### PR DESCRIPTION
cofh mods will no longer post updates in chat when you join game which is a complaninant many people have made 
also allowed ops to have access to secure blocks
