### PR TITLE
disabled compendium updates and targeting creative players

### DIFF
--- a/src/config/AM2/AM2.cfg
+++ b/src/config/AM2/AM2.cfg
@@ -34,10 +34,10 @@ enchantments {
 
 general {
     # If true, AM2 will automatically download compendium updates when available for your mod version.
-    B:Allow_Compendium_Updates=true
+    B:Allow_Compendium_Updates=false
 
     # Disable this to prevent spell effects on creative players
-    B:Allow_Creative_Targets=true
+    B:Allow_Creative_Targets=false
 
     # If true, AM2 will notify you via the compendium when new versions are available.  It will not spam chat on login.  You will not be notified of updates that are not for your current Minecraft version.
     B:Allow_Version_Checks=false


### PR DESCRIPTION
disabled compendium updates and targeting creative players as staff could be targeted when working and it will auto download compendium updates which could cause issues
